### PR TITLE
Bump play versions to 2.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HALselhof
-A [HAL](http://tools.ietf.org/html/draft-kelly-json-hal) library based on [Play-JSON](https://www.playframework.com/documentation/2.3.x/ScalaJson). 
+A [HAL](http://tools.ietf.org/html/draft-kelly-json-hal) library based on [Play-JSON](https://www.playframework.com/documentation/2.5.x/ScalaJson).
 
 [![Build Status](https://travis-ci.org/tobnee/HALselhof.svg?branch=master)](https://travis-ci.org/tobnee/HALselhof)
 
@@ -10,9 +10,9 @@ To use this library, add the following settings to your build definition:
 ```
 resolvers += "restful-scala" at "https://dl.bintray.com/restfulscala/maven"
 
-libraryDependencies += "org.restfulscala" %% "halselhof" % "0.1.0"
+libraryDependencies += "org.restfulscala" %% "halselhof" % "0.1.1"
 
-libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.0"
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.5.4"
 ```
 
 You need to add the `play-json` dependency explicitly, as _HALselhof_ assumed it is being provided by your application. If you use this library with the Play framework, _play-json_ should already be on your classpath.

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "halselhof"
 
 organization := "org.restfulscala"
 
-version := "0.1.0"
+version := "0.1.1"
 
 scalaVersion := "2.11.5"
 
@@ -14,9 +14,9 @@ resolvers += "typesafe repo" at "http://repo.typesafe.com/typesafe/releases/"
 
 scalariformSettings
 
-libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.7" % "provided"
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.5.4" % "provided"
 
-libraryDependencies += "com.typesafe.play" %% "play" % "2.3.7" % "provided"
+libraryDependencies += "com.typesafe.play" %% "play" % "2.5.4" % "provided"
 
 libraryDependencies += "org.scalatestplus" %% "play" % "1.1.0" % "test"
 


### PR DESCRIPTION
I included HALselhof 0.1.0 in my Play 2.5.4 project. When serializing a `HalResource` instance to JSON, this exception occurs:

```
java.lang.RuntimeException: java.lang.NoSuchMethodError: play.api.libs.json.JsObject.<init>(Lscala/collection/Seq;)V
```

I believe this is because HALselhof 0.1.0 was compiled against play-json 2.4.0 which has a binary incompatibility with play-json 2.5.4. Applying the changes in this PR, rebuilding and publishing to my local Ivy cache resolved the issue for me.

I'd love to learn how multiple versions of this library compiled against the various play-json versions can be provided. Also, I'm not sure how the HALSelhof version should be adjusted. See also #1.
